### PR TITLE
Error strict types

### DIFF
--- a/src/Resource/Error.php
+++ b/src/Resource/Error.php
@@ -36,14 +36,14 @@ class Error implements ResourceInterface
      * @param string $source
      * @param mixed $code
      */
-    public function __construct(string $message, string $source = '', $code = null)
+    public function __construct(string $message, string $source = null, $code = null)
     {
         if (!is_null($code)) {
             $code = (string) $code;
         }
 
         $this->message = $message;
-        $this->source = $source;
+        $this->source = (string) $source;
         $this->code = $code;
     }
 

--- a/src/Resource/Error.php
+++ b/src/Resource/Error.php
@@ -25,7 +25,7 @@ class Error implements ResourceInterface
     /**
      * The error code
      *
-     * @var mixed
+     * @var null|string
      */
     private $code;
 
@@ -36,8 +36,12 @@ class Error implements ResourceInterface
      * @param string $source
      * @param mixed $code
      */
-    public function __construct(string $message, string $source = null, $code = null)
+    public function __construct(string $message, string $source = '', $code = null)
     {
+        if (!is_null($code)) {
+            $code = (string) $code;
+        }
+
         $this->message = $message;
         $this->source = $source;
         $this->code = $code;

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -215,7 +215,7 @@ class ResponseFactoryTest extends TestCase
         $this->assertSame(400, $response->getStatusCode());
 
         $this->assertSame(
-            '{"errors":[{"code":null,"source":null,"message":"foo"}]}',
+            '{"errors":[{"code":null,"source":"","message":"foo"}]}',
             $response->getBody()->__toString()
         );
     }


### PR DESCRIPTION
Strict type casting for properties 'code' and 'source' in resource 'Error'.
$source can only be a string or an empty string.
$code can only be a string or null.
